### PR TITLE
Add support for pasting data from PDF in Rich Text Format

### DIFF
--- a/clipboard_windows.py
+++ b/clipboard_windows.py
@@ -1,0 +1,97 @@
+import ctypes
+from ctypes.wintypes import BOOL, HWND, HANDLE, HGLOBAL, UINT, LPVOID, INT, LPWSTR
+from ctypes import c_size_t as SIZE_T
+from typing import List, Tuple, Optional
+import os
+
+OpenClipboard = ctypes.windll.user32.OpenClipboard
+OpenClipboard.argtypes = HWND,
+OpenClipboard.restype = BOOL
+EmptyClipboard = ctypes.windll.user32.EmptyClipboard
+EmptyClipboard.restype = BOOL
+GetClipboardData = ctypes.windll.user32.GetClipboardData
+GetClipboardData.argtypes = UINT,
+GetClipboardData.restype = HANDLE
+SetClipboardData = ctypes.windll.user32.SetClipboardData
+SetClipboardData.argtypes = UINT, HANDLE
+SetClipboardData.restype = HANDLE
+CloseClipboard = ctypes.windll.user32.CloseClipboard
+CloseClipboard.restype = BOOL
+CountClipboardFormats = ctypes.windll.user32.CountClipboardFormats
+CountClipboardFormats.restype = INT
+EnumClipboardFormats = ctypes.windll.user32.EnumClipboardFormats
+EnumClipboardFormats.argtypes = UINT,
+EnumClipboardFormats.restype = UINT
+GetClipboardFormatName = ctypes.windll.user32.GetClipboardFormatNameW
+GetClipboardFormatName.argtypes = UINT, LPWSTR, INT
+GetClipboardFormatName.restype = INT
+
+CF_UNICODETEXT = 13
+
+GlobalAlloc = ctypes.windll.kernel32.GlobalAlloc
+GlobalAlloc.argtypes = UINT, SIZE_T
+GlobalAlloc.restype = HGLOBAL
+GlobalLock = ctypes.windll.kernel32.GlobalLock
+GlobalLock.argtypes = HGLOBAL,
+GlobalLock.restype = LPVOID
+GlobalUnlock = ctypes.windll.kernel32.GlobalUnlock
+GlobalUnlock.argtypes = HGLOBAL,
+GlobalSize = ctypes.windll.kernel32.GlobalSize
+GlobalSize.argtypes = HGLOBAL,
+GlobalSize.restype = SIZE_T
+
+GMEM_MOVEABLE = 0x0002
+GMEM_ZEROINIT = 0x0040
+
+unicode_type = type(u'')
+
+
+def list_clipboard_format() -> List[Tuple[int, str]]:
+    """Checks all the available clipboard data formats"""
+    buffer = ctypes.create_unicode_buffer(80)
+    formats = []
+    format_id = EnumClipboardFormats(0)
+    while format_id != 0:
+        if GetClipboardFormatName(format_id, buffer, 80) > 0:
+            formats.append((format_id, buffer.value))
+        format_id = EnumClipboardFormats(format_id)
+    return formats
+
+
+def is_windows():
+    return os.name == 'nt'
+
+
+def paste_windows() -> Tuple[str, Optional[str]]:
+    """
+    Tries to get data in RTF format. If not available, returns normal unicode
+    :return: tuple (data_format, string)
+    """
+    text = None
+    OpenClipboard(None)
+    formats = list_clipboard_format()
+    fmt = next(filter(lambda x: x[1] == "Rich Text Format", formats), (CF_UNICODETEXT, "Unicode"))
+    handle = GetClipboardData(fmt[0])
+    pcontents = GlobalLock(handle)
+    size = GlobalSize(handle)
+    if pcontents and size:
+        raw_data = ctypes.create_string_buffer(size)
+        ctypes.memmove(raw_data, pcontents, size)
+        text = raw_data.raw.decode('utf-8').rstrip(u'\0')
+    GlobalUnlock(handle)
+    CloseClipboard()
+    return fmt[1], text
+
+
+def put(s):
+    if not isinstance(s, unicode_type):
+        s = s.decode('mbcs')
+    data = s.encode('utf-16le')
+    OpenClipboard(None)
+    EmptyClipboard()
+    handle = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, len(data) + 2)
+    pcontents = GlobalLock(handle)
+    ctypes.memmove(pcontents, data, len(data))
+    GlobalUnlock(handle)
+    SetClipboardData(CF_UNICODETEXT, handle)
+    CloseClipboard()

--- a/clipboard_windows.py
+++ b/clipboard_windows.py
@@ -81,17 +81,3 @@ def paste_windows() -> Tuple[str, Optional[str]]:
     GlobalUnlock(handle)
     CloseClipboard()
     return fmt[1], text
-
-
-def put(s):
-    if not isinstance(s, unicode_type):
-        s = s.decode('mbcs')
-    data = s.encode('utf-16le')
-    OpenClipboard(None)
-    EmptyClipboard()
-    handle = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, len(data) + 2)
-    pcontents = GlobalLock(handle)
-    ctypes.memmove(pcontents, data, len(data))
-    GlobalUnlock(handle)
-    SetClipboardData(CF_UNICODETEXT, handle)
-    CloseClipboard()

--- a/rtf.py
+++ b/rtf.py
@@ -1,0 +1,94 @@
+﻿import regex as re
+
+# rtf reference
+# https://www.biblioscape.com/rtf15_spec.htm
+
+ignored_tags = list(map(lambda x: re.compile(x), [
+    r"q(l|r|j|c)",  # text alignment
+    "ulnone",  # underline none
+    "strike0",  # strike none
+    "pard",  # remove style of prev paragraph
+    "plain",  # reset font
+    r"s\d+",  # paragraph style
+    r"fi\d+",  # first line indent
+    r"li\d+",  # left indent
+    r"sl\d+",  # space between lines
+    r"slmult\d+",  # spacing multiple
+    r"f\d+",  # font id
+    r"fs\d+",  # font size
+    r"cf\d+",  # foreground color
+    r"^marg.*",  # margin-related tags
+    r"^pg.*",  # page-related tags
+    r"^paper.*",  # paper-related tags
+    r"'\d+",  # unicode char supplementary tag
+]))
+
+replace_tags = list(map(lambda x: (re.compile(x[0]), x[1]), [
+    ["i", "<em>"],
+    ["i0", "</em>"],
+    ["b", "<strong>"],
+    ["b0", "</strong>"],
+    ["rquote", "'"],
+    ["emdash", "—"],
+    ["endash", "–"],
+    ["par", "\n"],
+    [r"^u(\d+)", lambda m: chr(int(m.group(1)))],  # unicode char
+    [r"^_(.*)", lambda m: "-" + m.group(1)],  # non-breaking hyphen
+]))
+
+
+def preformat_rtf(s: str) -> str:
+    s = s.replace("\r\n", "")
+    s = s.replace("\n", "")
+
+    s = remove_rtf_header(s)
+    s = re.sub(r"(?:(?<!\\)\\(?!\\))([^\s]+)\s", process_rtf_tag_group, s)
+
+    s = resort_tags(s)
+
+    # remove opening/closing brackets
+    s = re.sub(r"(^\{\s+)|(\s+\}$)", "", s)
+    return s
+
+
+def remove_rtf_header(s: str) -> str:
+    """Removes style/font definitions"""
+    brackets = re.compile(r"\{(?!\\rtf)[^{}]+\}")
+    m = brackets.search(s)
+    while m:
+        s = s[:m.start(0)] + s[m.end(0):]
+        m = brackets.search(s)
+    return s
+
+
+def process_rtf_tag_group(match: re.Match) -> str:
+    tags = match.group(1).split("\\")
+    if tags[0].startswith("rtf"):
+        return ""
+    res = ""
+
+    def process_tag(t):
+        for r in ignored_tags:
+            if r.fullmatch(t):
+                return ""
+        for e in replace_tags:
+            if e[0].fullmatch(t):
+                return e[0].sub(e[1], t)
+        return "\\" + t
+
+    for t in tags:
+        res += process_tag(t)
+
+    # print(match.group(1))
+    # print(res)
+    return res
+
+
+def resort_tags(s: str):
+    s = re.sub(r"<(\w+)> ", lambda m: " <" + m.group(1) + ">", s)
+    s = re.sub(r" </(\w+)>", lambda m: "</" + m.group(1) + "> ", s)
+
+    # stitch over line breaks
+    s = re.sub(r"</(\w+)>(\s)<\1>", lambda m: m.group(2), s)
+
+    return s


### PR DESCRIPTION
Will add an option to import data from PDF in Rich Text Format.

Main benefit - should recognize when characters are in italics or bold.
Currently strips most of RTF tags, but those potentially can be used as additional style info.

Unfortunately, Windows only. Had to use winapi directly, as pyperclip doesn't support it.
Hopefully, it will not break the rest of the program on other os, but I can't test it.

The option is off by default.
Unfortunately, reformat function doesn't work quite well with the RTF-sourced data as it doesn't expect html tags.